### PR TITLE
An attempt to fix (or work around) diegomura/react-pdf#600

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ export const wrap = async (elements, height, pageNumber) => {
     const futureElements = elements.slice(i + 1)
     const isElementOutside = height <= element.top
     const elementShouldSplit = height < element.top + element.height
-    let elementShouldBreak = element.break || (!element.wrap && elementShouldSplit)
+    const elementFitsFullPageHeight = element.height <= height;
+    let elementShouldBreak = element.break || (!element.wrap && elementShouldSplit && elementFitsFullPageHeight)
 
     // If element is fixed, we add it both to the current page
     // and to all future pages to come.

--- a/test/index.js
+++ b/test/index.js
@@ -178,6 +178,23 @@ describe('page-wrapping', () => {
     expect(result[1].children[0].height).toBe(70)
   })
 
+  // For fixing https://github.com/diegomura/react-pdf/issues/600
+  test('Should ignore wrap=false flag if element does not fit on a full page after a break', async () => {
+    const page = node({ left: 0, top: 0, width: 110, height: 150, wrap: false })
+
+    const result = await wrapPages(page, 100)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].left).toBe(0)
+    expect(result[0].top).toBe(0)
+    expect(result[0].width).toBe(110)
+    expect(result[0].height).toBe(100)
+    expect(result[1].left).toBe(0)
+    expect(result[1].top).toBe(0)
+    expect(result[1].width).toBe(110)
+    expect(result[1].height).toBe(50)
+  })
+
   test('Should repeat fixed elements in all pages', async () => {
     const page = node({ left: 0, top: 0, width: 110, height: 120 })
     const child1 = node({ left: 10, top: 10, width: 100, height: 10, fixed: true })

--- a/test/index.js
+++ b/test/index.js
@@ -180,7 +180,7 @@ describe('page-wrapping', () => {
 
   // For fixing https://github.com/diegomura/react-pdf/issues/600
   test('Should ignore wrap=false flag if element does not fit on a full page after a break', async () => {
-    const page = node({ left: 0, top: 0, width: 110, height: 150, wrap: false })
+    const page = node({ left: 0, top: 0, width: 110, height: 101, wrap: false })
 
     const result = await wrapPages(page, 100)
 
@@ -192,7 +192,25 @@ describe('page-wrapping', () => {
     expect(result[1].left).toBe(0)
     expect(result[1].top).toBe(0)
     expect(result[1].width).toBe(110)
-    expect(result[1].height).toBe(50)
+    expect(result[1].height).toBe(1)
+  })
+
+  // For fixing https://github.com/diegomura/react-pdf/issues/600
+  test('Should comply with wrap=false flag if element does fit on a full page after a break', async () => {
+    const page = node({ left: 0, top: 0, width: 110, height: 150 })
+    const child = node({ left: 0, top: 10, width: 100, height: 100, wrap: false })
+
+    page.appendChild(child)
+
+    const result = await wrapPages(page, 100)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].children).toHaveLength(0)
+    expect(result[1].children).toHaveLength(1)
+    expect(result[1].children[0].left).toBe(0)
+    expect(result[1].children[0].top).toBe(0)
+    expect(result[1].children[0].width).toBe(100)
+    expect(result[1].children[0].height).toBe(100)
   })
 
   test('Should repeat fixed elements in all pages', async () => {


### PR DESCRIPTION
I know you're working on a new page wrapping algorithm, but I wonder if you in the mean time would accept something like this, to prevent ReactPDF from hanging on `wrap=false` on large nodes?